### PR TITLE
normalize answers for subscript/superscript handling

### DIFF
--- a/app/study/practice/page.tsx
+++ b/app/study/practice/page.tsx
@@ -105,8 +105,9 @@ function PracticePage() {
   }, [currentCardIndex, shuffledCards, shuffleCards]);
 
   const validateAnswer = (guess: string, rightAnswer: string): boolean => {
-    guess = guess.toLowerCase().trim();
-    rightAnswer = rightAnswer.toLowerCase().trim();
+    // normalize NFKD is used here to turn subscript and superscript characters to their normal counterparts
+    guess = guess.normalize("NFKD").replace(/−/g, "-").toLowerCase().trim();
+    rightAnswer = rightAnswer.normalize("NFKD").replace(/−/g, "-").toLowerCase().trim();
     if (guess == rightAnswer) {
       return true;
     }


### PR DESCRIPTION
normalize answers using [`String.prototype.normalize()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize) to allow superscript/subscripts to be equivalent to their normal sized form