### PR TITLE
somewhat hacky dark mode fix for the Table element on /study

### DIFF
--- a/app/study/page.tsx
+++ b/app/study/page.tsx
@@ -26,7 +26,6 @@ const StudySet = () => {
 
   useEffect(() => {
     const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    console.log(darkMode)
     setIsDarkMode(darkMode);
   }, []); 
 

--- a/app/study/page.tsx
+++ b/app/study/page.tsx
@@ -13,6 +13,7 @@ const filterCategories = ["New", "Challenging", "Familiar", "Proficient", "Starr
 
 const StudySet = () => {
   const searchParams = useSearchParams();
+  const [isDarkMode, setIsDarkMode] = useState(false);
   const [currentCardIndex, setCurrentCardIndex] = useState(0);
   const [isFlipped, setIsFlipped] = useState(false);
   const [direction, setDirection] = useState(0);
@@ -22,6 +23,12 @@ const StudySet = () => {
     { id: number; set: number; term: string; definition: string; difficulty: string }[]
   >([{ id: 1, set: -1, term: "Loading...", definition: "Loading...", difficulty: "New" }]);
   const [status, setStatus] = useState("Loading...");
+
+  useEffect(() => {
+    const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    console.log(darkMode)
+    setIsDarkMode(darkMode);
+  }, []); 
 
   useEffect(() => {
     const setIdStr = searchParams.get("set-id");
@@ -168,7 +175,7 @@ const StudySet = () => {
             <ChevronRight className="h-4 w-4" />
           </Button>
         </div>
-        <div className="text-sm text-muted-foreground">
+        <div className="text-sm dark:text-muted-foreground">
           Card {currentCardIndex + 1} of {flashcards.length}
         </div>
       </div>
@@ -213,7 +220,7 @@ const StudySet = () => {
             </Button>
           ))}
         </div>
-        <Table>
+        <Table className={isDarkMode ? 'dark' : ''}>
           <TableHeader>
             <TableRow>
               <TableHead>Term</TableHead>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,7 +6,7 @@ const config: Config = {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  darkMode: ["class"],
+  darkMode: ["selector"],
   theme: {
     extend: {
       colors: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,9 +22,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "target": "ES2017"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
the Table element always used the light mode colors for some reason. I force it to use dark mode colors by setting `className="dark"` if and only if `window.matchMedia('(prefers-color-scheme: dark)').matches` is true on page load