### PR TITLE
fix issue where switching the direction of flashcard display uses wrong exit animation

### DIFF
--- a/app/study/page.tsx
+++ b/app/study/page.tsx
@@ -41,6 +41,18 @@ const FlashcardsDisplay = (props: FlashcardProps) => {
     setIsFlipped(!isFlipped);
   };
 
+  const variants = {
+    initial: (direction: number) => ({
+      opacity: 0,
+      x: direction === 1 ? 100 : -100,
+    }),
+
+    exit: (direction: number) => ({
+      opacity: 0,
+      x: direction === 1 ? -100 : 100,
+    }),
+  };
+
   return (
     <div className="flex flex-col items-center mb-8">
       <div className="flex justify-center items-center w-full max-w-2xl mb-4">
@@ -53,12 +65,14 @@ const FlashcardsDisplay = (props: FlashcardProps) => {
         >
           <ChevronLeft className="h-4 w-4" />
         </Button>
-        <AnimatePresence mode="wait" initial={false}>
+        <AnimatePresence mode="wait" initial={false} custom={direction}>
           <motion.div
             key={currentCardIndex}
-            initial={{ opacity: 0, x: direction > 0 ? 100 : -100 }}
+            custom={direction}
+            variants={variants}
+            initial="initial"
             animate={{ opacity: 1, x: 0 }}
-            exit={{ opacity: 0, x: direction > 0 ? -100 : 100 }}
+            exit="exit"
             transition={{ duration: 0.3 }}
             className="mx-4 w-full"
           >


### PR DESCRIPTION
See https://sinja.io/blog/direction-aware-animations-in-framer-motion#solution

My understanding of this issue is this: basically when you are implementing a bidirectional carousel you have to use a function in variants to determine initial and exit animations based on direction. If you just do it in the attributes like I did before "the exiting component will use the older value, which it received on the previous render" because the component is unmounted by React.