### PR TITLE
Fix firefox issue of overlapping text on flipped flashcards

### DIFF
--- a/app/study/page.tsx
+++ b/app/study/page.tsx
@@ -82,10 +82,10 @@ const FlashcardsDisplay = (props: FlashcardProps) => {
                 transition={{ duration: 0.5 }}
                 className="w-full h-full [transform-style:preserve-3d]"
               >
-                <CardContent className="flex items-center justify-center h-full p-6 text-center absolute w-full [backface-visibility:hidden]">
+                <CardContent className="flex items-center justify-center h-full p-6 text-center absolute w-full [backface-visibility:hidden] [transform:rotateX(0deg)] [transform:rotateY(0deg)]">
                   <p className="text-xl">{flashcards[currentCardIndex].term}</p>
                 </CardContent>
-                <CardContent className="flex items-center justify-center h-full p-6 text-center absolute w-full [backface-visibility:hidden] [transform:rotateY(180deg)]">
+                <CardContent className="flex items-center justify-center h-full p-6 text-center absolute w-full [backface-visibility:hidden] [transform:rotateX(0deg)] [transform:rotateY(180deg)]">
                   <p className="text-xl">{flashcards[currentCardIndex].definition}</p>
                 </CardContent>
               </motion.div>


### PR DESCRIPTION
#5 

See: [https://stackoverflow.com/a/32421734](https://stackoverflow.com/a/32421734). I also had to put `transform:rotateY(0deg)` on the front card probably because `transform:rotateY(180deg)` was in the back card.